### PR TITLE
Add Luigi character support and switching logic

### DIFF
--- a/header/Baddie.h
+++ b/header/Baddie.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Mario.h"
+#include "Player.h"
 #include "raylib.h"
 #include "Sprite.h"
 
@@ -27,7 +27,7 @@ public:
 
     void update() override = 0;
     void draw() override = 0;
-    void activateWithMarioProximity( Mario &mario );
+    void activateWithPlayerProximity( Player &player );
     virtual void setAttributesOnDying();
     virtual void onSouthCollision();
     virtual void onHit();

--- a/header/Block.h
+++ b/header/Block.h
@@ -3,7 +3,7 @@
 #include "Map.h"
 #include "raylib.h"
 #include "Sprite.h"
-#include "Mario.h"
+#include "Player.h"
 #include <string>
 
 //Base class for all blocks in the game
@@ -21,7 +21,7 @@ public:
 
 	void update() override = 0;
 	void draw() override = 0;
-	virtual void doHit(Mario& mario, Map* map);
+	virtual void doHit(Player& player, Map* map);
 	void resetHit();
 	bool isHit() const;
 	virtual std::string getType() const = 0;
@@ -131,7 +131,7 @@ public:
 	void update() override;
 	void draw() override;
 
-	void doHit(Mario& mario, Map* map) override;
+	void doHit(Player& player, Map* map) override;
 	std::string getType() const override {
 		return "QuestionBlock";
 	}
@@ -151,7 +151,7 @@ public:
 	void update() override;
 	void draw() override;
 
-	void doHit(Mario& mario, Map* map) override;
+	void doHit(Player& player, Map* map) override;
 	std::string getType() const override {
 		return "QuestionMushroomBlock";
 	}
@@ -171,7 +171,7 @@ public:
 	void update() override;
 	void draw() override;
 
-	void doHit(Mario& mario, Map* map) override;
+	void doHit(Player& player, Map* map) override;
 	std::string getType() const override {
 		return "QuestionFireFlowerBlock";
 	}
@@ -191,7 +191,7 @@ public:
 	void update() override;
 	void draw() override;
 
-	void doHit(Mario& mario, Map* map) override;
+	void doHit(Player& player, Map* map) override;
 	std::string getType() const override {
 		return "QuestionStarBlock";
 	}
@@ -211,7 +211,7 @@ public:
 	void update() override;
 	void draw() override;
 
-	void doHit(Mario& mario, Map* map) override;
+	void doHit(Player& player, Map* map) override;
 	std::string getType() const override {
 		return "QuestionOneUpMushroomBlock";
 	}
@@ -231,7 +231,7 @@ public:
 	void update() override;
 	void draw() override;
 
-	void doHit(Mario& mario, Map* map) override;
+	void doHit(Player& player, Map* map) override;
 	std::string getType() const override {
 		return "QuestionThreeUpMoonBlock";
 	}
@@ -262,7 +262,7 @@ public:
 	void update() override;
 	void draw() override;
 
-	void doHit(Mario& mario, Map* map) override;
+	void doHit(Player& player, Map* map) override;
 	std::string getType() const override {
 		return "ExclamationBlock";
 	}
@@ -277,7 +277,7 @@ public:
 	void update() override;
 	void draw() override;
 
-	void doHit(Mario& mario, Map* map) override;
+	void doHit(Player& player, Map* map) override;
 	std::string getType() const override {
 		return "InvisibleBlock";
 	}
@@ -292,7 +292,7 @@ public:
 	void update() override;
 	void draw() override;
 
-	void doHit(Mario& mario, Map* map) override;
+	void doHit(Player& player, Map* map) override;
 	std::string getType() const override {
 		return "MessageBlock";
 	}

--- a/header/Data.h
+++ b/header/Data.h
@@ -5,7 +5,7 @@
 #include "Block.h"
 #include "Baddie.h"
 #include "Item.h"
-#include "MarioType.h"
+#include "PlayerType.h"
 #include "raylib.h"
 
 struct Data{
@@ -26,7 +26,7 @@ struct bigData : public Data {
     std::vector<Item*> items;
     std::vector<Item*> staticItems;
 
-    bigData(int mID, int sc, int lv, int c, int yC, MarioType mType)
+    bigData(int mID, int sc, int lv, int c, int yC, PlayerType mType)
         : Data(mID, sc, lv, c, yC, mType) {}
 
 	bigData(int mID, int sc, int lv, int c, int yC, int cT, std::vector<Block*> blks,

--- a/header/GameWorld.h
+++ b/header/GameWorld.h
@@ -1,6 +1,6 @@
 #pragma once
 
-class Mario;
+class Player;
 
 #include "Drawable.h"
 #include "GameState.h"
@@ -19,7 +19,7 @@ class Mario;
 #include "LeaderBoardScreen.h"
 #include "CareTaker.h"
 #include "Memento.h"
-#include "Mario.h"
+#include "Player.h"
 #include "raylib.h"
 #include <iostream>
 
@@ -38,7 +38,7 @@ class GameWorld : public virtual Drawable {
     friend class CareTaker;
     friend class SettingScreen;
 
-    Mario mario;
+    Player player;
     Map map;
     Camera2D* camera;
     bool settingBoardIsOpen;
@@ -49,7 +49,7 @@ class GameWorld : public virtual Drawable {
     int totalPlayedTime;
 
     bool pauseMusic;
-    bool pauseMario;
+    bool pausePlayer;
     // bool showOverlayOnPause;
 
     bool outroFinished;
@@ -73,7 +73,7 @@ class GameWorld : public virtual Drawable {
 
 public:
 
-    // static bool immortalMario;
+    // static bool immortalPlayer;
     static GameState state;
     static float gravity;
 
@@ -99,7 +99,7 @@ public:
     void resetMap();
     void resetGame();
     void nextMap();
-    void pauseGame(bool playPauseSFX, bool pauseMusic, bool pauseMario, bool showSettingBoard, bool showHelpingBoard);
+    void pauseGame(bool playPauseSFX, bool pauseMusic, bool pausePlayer, bool showSettingBoard, bool showHelpingBoard);
     void unpauseGame();
     void showGuardScreen(GuardAction action);
 

--- a/header/Item.h
+++ b/header/Item.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "raylib.h"
 #include "Sprite.h"
-#include "Mario.h"
+#include "Player.h"
 #include <string>
 
 // Base class for all items in the game
@@ -28,8 +28,8 @@ public:
     void update() override = 0;
     void draw() override = 0;
     virtual void playCollisionSound() = 0;
-    virtual void updateMario(Mario& mario) = 0;
-    virtual void onSouthCollision(Mario& mario);
+    virtual void updatePlayer(Player& player) = 0;
+    virtual void onSouthCollision(Player& player);
     virtual bool isPauseGameOnHit();
 	virtual std::string getType() const = 0;
 };
@@ -42,7 +42,7 @@ public:
     void update() override;
     void draw() override;
     void playCollisionSound() override;
-    void updateMario(Mario& mario) override;
+    void updatePlayer(Player& player) override;
     CollisionType checkCollision(Sprite* sprite) override;
     std::string getType() const override {
         return "Coin";
@@ -65,8 +65,8 @@ public:
     void update() override;
     void draw() override;
     void playCollisionSound() override;
-    void updateMario(Mario& mario) override;
-    void onSouthCollision(Mario& mario) override;
+    void updatePlayer(Player& player) override;
+    void onSouthCollision(Player& player) override;
 	std::string getType() const override {
 		return "Mushroom";
 	}
@@ -81,7 +81,7 @@ public:
     void update() override;
     void draw() override;
     void playCollisionSound() override;
-    void updateMario(Mario& mario) override;
+    void updatePlayer(Player& player) override;
 	std::string getType() const override {
 		return "OneUpMushroom";
 	}
@@ -104,8 +104,8 @@ public:
     void update() override;
     void draw() override;
     void playCollisionSound() override;
-    void updateMario(Mario& mario) override;
-    void onSouthCollision(Mario& mario) override;
+    void updatePlayer(Player& player) override;
+    void onSouthCollision(Player& player) override;
 	std::string getType() const override {
 		return "FireFlower";
 	}
@@ -119,8 +119,8 @@ public:
     void update() override;
     void draw() override;
     void playCollisionSound() override;
-    void updateMario(Mario& mario) override;
-    void onSouthCollision(Mario& mario) override;
+    void updatePlayer(Player& player) override;
+    void onSouthCollision(Player& player) override;
 	std::string getType() const override {
 		return "Star";
 	}
@@ -135,7 +135,7 @@ public:
     void update() override;
     void draw() override;
     void playCollisionSound() override;
-    void updateMario(Mario& mario) override;
+    void updatePlayer(Player& player) override;
 	std::string getType() const override {
 		return "ThreeUpMoon";
 	}
@@ -153,7 +153,7 @@ public:
     void update() override;
     void draw() override;
     void playCollisionSound() override;
-    void updateMario(Mario& mario) override;
+    void updatePlayer(Player& player) override;
     CollisionType checkCollision(Sprite* sprite) override;
     std::string getType() const override {
         return "YoshiCoin";
@@ -168,7 +168,7 @@ public:
 	void update() override;
 	void draw() override;
 	void playCollisionSound() override;
-	void updateMario(Mario& mario) override;
+	void updatePlayer(Player& player) override;
 	CollisionType checkCollision(Sprite* sprite) override;
 	std::string getType() const override {
 		return "CourseClearToken";

--- a/header/Map.h
+++ b/header/Map.h
@@ -6,7 +6,7 @@ class GameWorld;
 #include "raylib.h"
 #include "json.hpp"
 #include "Tile.h"
-#include "Mario.h"
+#include "Player.h"
 #include "Baddie.h"
 #include "Tile.h"
 #include "Block.h"
@@ -31,8 +31,8 @@ class Map : public virtual Drawable {
     float maxWidth;
     float maxHeight;
 
-    Mario& mario;
-    float marioOffset;
+    Player& player;
+    float playerOffset;
 
     int backgroundId;
     int maxBackgroundId;
@@ -47,7 +47,7 @@ class Map : public virtual Drawable {
     float drawBlackScreenFadeTime;
 
     // Near sight vision effect for map3
-    Vector2 lastValidMarioPos;
+    Vector2 lastValidPlayerPos;
     
     //bool parseBlocks;
     //bool parseItems;
@@ -65,14 +65,14 @@ public:
 
     static constexpr int TILE_WIDTH = 32;
 
-    Map(Mario& mario, int id, bool loadTestMap, GameWorld* gw);
+    Map(Player& player, int id, bool loadTestMap, GameWorld* gw);
     ~Map() override;
     void draw() override;
 
     //void parseMap();
     void loadFromJsonFile(bool shouldLoadTestMap = false);
 
-    void setMarioOffset(float marioOffset);
+    void setPlayerOffset(float playerOffset);
     void setDrawBlackScreen(bool drawBlackScreen);
     void setCamera(Camera2D* camera);
     void setGameWorld(GameWorld* gw);

--- a/header/MarioType.h
+++ b/header/MarioType.h
@@ -1,7 +1,0 @@
-#pragma once
-
-enum MarioType {
-	MARIO_TYPE_SMALL,
-	MARIO_TYPE_SUPER,
-	MARIO_TYPE_FLOWER
-};

--- a/header/Player.h
+++ b/header/Player.h
@@ -7,12 +7,12 @@ class Map;
 #include "CollisionType.h"
 #include "Direction.h"
 #include "Fireball.h"
-#include "MarioType.h"
+#include "PlayerType.h"
 #include "raylib.h"
 #include "Sprite.h"
 #include <vector>
 
-class Mario : public Sprite {
+class Player : public Sprite {
 
 	float speedX; // Base horizontal speed (walking speed)
 	float maxSpeedX; // Maximum horizontal speed (running speed)
@@ -28,7 +28,7 @@ class Mario : public Sprite {
 	bool ducking; // Whether the player is ducking, is 'true' when holding DOWN
 	bool lookingUp; // Whether the player is looking up, is 'true' when holding UP
 	bool running; // Whether the player is running, is 'true' when holding CTRL
-	bool invincible; // Whether the player is invincible, is 'true' when Mario has Star power
+	bool invincible; // Whether the player is invincible, is 'true' when Player has Star power
 
 	float frameTimeWalking; // Time between frames when walking
 	float frameTimeRunning; // Time between frames when running (faster animation)
@@ -44,12 +44,12 @@ class Mario : public Sprite {
 	float maxTime;
 	float ellapsedTime;
 
-	MarioType type; // Current Mario form
+	PlayerType type; // Current Player form
 	
 	CollisionProbe cpE1; // Right-side collision detector
 	CollisionProbe cpW1; // Left-side collision detector
 
-	MarioType reservedPowerUp; // Power-Up stored in reserve
+	PlayerType reservedPowerUp; // Power-Up stored in reserve
 
 	std::vector<Fireball> fireballs;
 
@@ -70,7 +70,7 @@ class Mario : public Sprite {
 	const int superToFlowerTransitionFrameOrder[11] = { 0, 1, 0, 1, 0, 1, 0, 1 }; // SUPER -> FLOWER
 
 	float invincibleTime; // Duration of invicibility
-	float invincibleAcum; // Accumulator to track how long Mario has been invincible
+	float invincibleAcum; // Accumulator to track how long Player has been invincible
 
 	bool playerDownMusicStreamPlaying;
 	bool gameOverMusicStreamPlaying;
@@ -84,8 +84,8 @@ class Mario : public Sprite {
 
 public:
 
-    Mario(Vector2 pos, Vector2 dim, Vector2 vel, Color color, float speedX, float maxSpeedX, float jumpSpeed, bool immortal);
-    ~Mario() override;
+    Player(Vector2 pos, Vector2 dim, Vector2 vel, Color color, float speedX, float maxSpeedX, float jumpSpeed, bool immortal);
+    ~Player() override;
 
     void update() override;
     void draw() override;
@@ -140,11 +140,11 @@ public:
     void changeToSuper();
     void changeToFlower();
 
-    void setReservedPowerUp(MarioType reservedPowerUp);
-    MarioType getReservedPowerUp() const;
+    void setReservedPowerUp(PlayerType reservedPowerUp);
+    PlayerType getReservedPowerUp() const;
 	/*void releaseReservedPowerUp();*/ // Needs Item class implementation
 
-    MarioType getType() const;
+    PlayerType getType() const;
     void setInvulnerable(bool invulnerable);
     bool isInvulnerable() const;
 

--- a/header/PlayerType.h
+++ b/header/PlayerType.h
@@ -1,0 +1,7 @@
+#pragma once
+
+enum PlayerType {
+	PLAYER_TYPE_SMALL,
+	PLAYER_TYPE_SUPER,
+	PLAYER_TYPE_FLOWER
+};

--- a/src/Baddie.cpp
+++ b/src/Baddie.cpp
@@ -1,5 +1,4 @@
 #include "Baddie.h"
-#include "Mario.h"
 #include "raylib.h"
 #include "SpriteState.h"
 
@@ -43,14 +42,14 @@ Baddie::Baddie( Vector2 pos, Vector2 dim, Vector2 vel, Color color, float frameT
 
 Baddie::~Baddie() = default;
 
-void Baddie::activateWithMarioProximity( Mario &mario ) {
+void Baddie::activateWithPlayerProximity( Player &player ) {
     if ( CheckCollisionPointRec( 
         Vector2{ pos.x + dim.x / 2, pos.y + dim.y / 2 },
         Rectangle{
-            mario.getX() + mario.getWidth() / 2 - mario.getActivationWidth() / 2,
-            mario.getY() + mario.getHeight() / 2 - mario.getActivationWidth() / 2,
-            mario.getActivationWidth(),
-            mario.getActivationWidth() })) {
+            player.getX() + player.getWidth() / 2 - player.getActivationWidth() / 2,
+            player.getY() + player.getHeight() / 2 - player.getActivationWidth() / 2,
+            player.getActivationWidth(),
+            player.getActivationWidth() })) {
         state = SPRITE_STATE_ACTIVE;
     }
 }

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -18,7 +18,7 @@ void Block::resetHit() {
 	hit = false;
 }
 
-void Block::doHit(Mario& mario, Map* map) {
+void Block::doHit(Player& player, Map* map) {
 	if (!hit)
 		hit = true;
 }
@@ -192,14 +192,14 @@ void QuestionBlock::draw() {
 	}
 }
 
-void QuestionBlock::doHit(Mario& mario, Map* map) {
+void QuestionBlock::doHit(Player& player, Map* map) {
 	if (!hit) {
 		PlaySound(ResourceManager::getInstance().getSounds()["coin"]);
 		hit = true;
 		coinAnimationRunning = true;
 		coinY = pos.y;
-		mario.addCoins(1);
-		mario.addPoints(earnedPoints);
+		player.addCoins(1);
+		player.addPoints(earnedPoints);
 	}
 }
 QuestionBlock::QuestionBlock(Vector2 pos, Vector2 dim, Color color) :
@@ -266,14 +266,14 @@ void QuestionMushroomBlock::draw() {
 		DrawRectangle(pos.x, pos.y, dim.x, dim.y, Fade(color, 0.5));
 	}
 }
-void QuestionMushroomBlock::doHit(Mario& mario, Map* map) {
+void QuestionMushroomBlock::doHit(Player& player, Map* map) {
 	if (!hit) {
 		hit = true;
 		Vector2 itemPos = { pos.x, pos.y - dim.y };
 		Vector2 itemDim = { 32, 32 }; // Assuming a standard item size
 		Vector2 itemVel = { 0, -150 }; // Initial velocity for the item
 		item = FactoryItem::createItem("Mushroom", itemPos, itemDim, itemVel, RED, true, true, false);
-		item->setFacingDirection(mario.getFacingDirection());
+		item->setFacingDirection(player.getFacingDirection());
 		itemMinY = pos.y - 32;
 		this->map = map;
 	}
@@ -336,14 +336,14 @@ void QuestionFireFlowerBlock::draw() {
 		DrawRectangle(pos.x, pos.y, dim.x, dim.y, Fade(color, 0.5));
 	}
 }
-void QuestionFireFlowerBlock::doHit(Mario& mario, Map* map) {
+void QuestionFireFlowerBlock::doHit(Player& player, Map* map) {
 	if (!hit) {
 		hit = true;
 		Vector2 itemPos = { pos.x, pos.y - dim.y };
 		Vector2 itemDim = { 32, 32 };
 		Vector2 itemVel = { 0, -150 };
 		this -> item = FactoryItem::createItem("FireFlower", itemPos, itemDim, itemVel, ORANGE, true, true, false);
-		item->setFacingDirection(mario.getFacingDirection());
+		item->setFacingDirection(player.getFacingDirection());
 		itemMinY = pos.y - 32;
 		this->map = map;
 	}
@@ -398,14 +398,14 @@ void QuestionStarBlock::draw() {
 		DrawRectangle(pos.x, pos.y, dim.x, dim.y, Fade(color, 0.5));
 	}
 }
-void QuestionStarBlock::doHit(Mario& mario, Map* map) {
+void QuestionStarBlock::doHit(Player& player, Map* map) {
 	if (!hit) {
 		hit = true;
 		Vector2 itemPos = { pos.x, pos.y - dim.y };
 		Vector2 itemDim = { 30, 32 }; 
 		Vector2 itemVel = { 0, -150 };
 		this -> item = FactoryItem::createItem("Star", itemPos, itemDim, itemVel, YELLOW, true, true, false);
-		item->setFacingDirection(mario.getFacingDirection());
+		item->setFacingDirection(player.getFacingDirection());
 		itemMinY = pos.y - 32;
 		this->map = map;
 	}
@@ -464,14 +464,14 @@ void QuestionOneUpMushroomBlock::draw() {
 		DrawRectangle(pos.x, pos.y, dim.x, dim.y, Fade(color, 0.5));
 	}
 }
-void QuestionOneUpMushroomBlock::doHit(Mario& mario, Map* map) {
+void QuestionOneUpMushroomBlock::doHit(Player& player, Map* map) {
 	if (!hit) {
 		hit = true;
 		Vector2 itemPos = { pos.x, pos.y - dim.y };
 		Vector2 itemDim = { 32, 32 };
 		Vector2 itemVel = { 0, -150 };
 		this->item = FactoryItem::createItem("OneUpMushroom", itemPos, itemDim, itemVel, YELLOW, true, true, false);
-		item->setFacingDirection(mario.getFacingDirection());
+		item->setFacingDirection(player.getFacingDirection());
 		itemMinY = pos.y - 32;
 		this->map = map;
 	}
@@ -530,14 +530,14 @@ void QuestionThreeUpMoonBlock::draw() {
 		DrawRectangle(pos.x, pos.y, dim.x, dim.y, Fade(color, 0.5));
 	}
 }
-void QuestionThreeUpMoonBlock::doHit(Mario& mario, Map* map) {
+void QuestionThreeUpMoonBlock::doHit(Player& player, Map* map) {
 	if (!hit) {
 		hit = true;
 		Vector2 itemPos = { pos.x, pos.y - dim.y };
 		Vector2 itemDim = { 32, 32 };
 		Vector2 itemVel = { 0, -150 };
 		this-> item = FactoryItem::createItem("ThreeUpMoon", itemPos, itemDim, itemVel, YELLOW, true, true, false);
-		item->setFacingDirection(mario.getFacingDirection());
+		item->setFacingDirection(player.getFacingDirection());
 		itemMinY = pos.y - 32;
 		this->map = map;
 	}
@@ -630,7 +630,7 @@ void ExclamationBlock::draw() {
 		DrawRectangle(pos.x, pos.y, dim.x, dim.y, Fade(color, 0.5));
 	}
 }
-void ExclamationBlock::doHit(Mario& mario, Map* map) {
+void ExclamationBlock::doHit(Player& player, Map* map) {
 	if (!hit) {
 		hit = true;
 		Vector2 itemPos = { pos.x, pos.y - dim.y };
@@ -640,8 +640,8 @@ void ExclamationBlock::doHit(Mario& mario, Map* map) {
 		if (item) {
 			map->getItems().push_back(item); // Add the item to the map's items vector
 		}
-		mario.addPoints(100);
-		mario.addCoins(1);
+		player.addPoints(100);
+		player.addCoins(1);
 	}
 }
 ExclamationBlock::ExclamationBlock(Vector2 pos, Vector2 dim, Color color) :
@@ -673,7 +673,7 @@ void InvisibleBlock::update() {
 void InvisibleBlock::draw() {
 
 }
-void InvisibleBlock::doHit(Mario& mario, Map* map) {
+void InvisibleBlock::doHit(Player& player, Map* map) {
 	if (!hit) {
 		hit = true;
 		Vector2 itemPos = { pos.x, pos.y - dim.y }; 
@@ -682,9 +682,9 @@ void InvisibleBlock::doHit(Mario& mario, Map* map) {
 		Item* item = FactoryItem::createItem("Coin", itemPos, itemDim, itemVel, YELLOW, true, true, false);
 		if (item) {
 			map->getItems().push_back(item); // Add the item to the map's items vector
-			mario.addCoins(1);
+			player.addCoins(1);
 		}
-		mario.addPoints(100); 
+		player.addPoints(100); 
 	}
 }
 InvisibleBlock::InvisibleBlock(Vector2 pos, Vector2 dim, Color color)
@@ -700,11 +700,11 @@ void MessageBlock::update() {
 void MessageBlock::draw() {
 	DrawTexture(ResourceManager::getInstance().getTexture("block96"), pos.x, pos.y, color);
 }
-void MessageBlock::doHit(Mario& mario, Map* map) {
+void MessageBlock::doHit(Player& player, Map* map) {
 	if (!hit) {
 		hit = true;
 		// Display a message or perform an action
-		mario.addPoints(50);
+		player.addPoints(50);
 	}
 }
 MessageBlock::MessageBlock(Vector2 pos, Vector2 dim, Color color)

--- a/src/GameWorld.cpp
+++ b/src/GameWorld.cpp
@@ -10,7 +10,7 @@ GameState GameWorld::state = GAME_STATE_TITLE_SCREEN;
 float GameWorld::gravity = 1200;
 
 GameWorld::GameWorld() :
-    mario( 
+    player( 
         {0,0},          // position
         {32, 40},       // dimention
         {0, 0},         // velocity
@@ -20,7 +20,7 @@ GameWorld::GameWorld() :
         -600,           // jumpSpeed
         false           
     ),
-    map(mario, 3, true, this),
+    map(player, 3, true, this),
     camera(nullptr),
     settingBoardIsOpen(false),
     helpingBoardIsOpen(false),
@@ -28,7 +28,7 @@ GameWorld::GameWorld() :
     remainingTimePointCount(0),
     totalPlayedTime(0),
     pauseMusic(false),
-    pauseMario(false),
+    pausePlayer(false),
     outroFinished(false),
     outroTime(1.0f),
     outroAcum(0.0f),
@@ -46,8 +46,8 @@ GameWorld::GameWorld() :
     helpingScreen(nullptr),
     guardScreen(nullptr)
     {
-        mario.setGameWorld(this);
-        mario.setMap(&map);
+        player.setGameWorld(this);
+        player.setMap(&map);
     }
 
 GameWorld::~GameWorld() {
@@ -103,7 +103,7 @@ GameWorld::~GameWorld() {
 }
 
 Memento* GameWorld::dataFromGameWorldToSave() {
-    // Data data(map.getId(), remainingTimePointCount, mario.getPoints(), mario.getLives(),
+    // Data data(map.getId(), remainingTimePointCount, player.getPoints(), player.getLives(),
     //          map.getBlocks(), map.getBaddies(), map.getItems(), map.getStaticItems());
     // return new ConcreteMemento(data);
     return nullptr;
@@ -121,11 +121,11 @@ void GameWorld::restoreDataFromMemento(const Memento* memento) const {
 Memento* GameWorld::dataFromGameWorldToLeaderboard() {
     Data data(
         map.getId(),
-        mario.getPoints(),
-        mario.getLives(),
-        mario.getCoins(),
-        mario.getYoshiCoins(),
-        mario.getType()
+        player.getPoints(),
+        player.getLives(),
+        player.getCoins(),
+        player.getYoshiCoins(),
+        player.getType()
     );
     return new ConcreteMemento(data);
 }
@@ -188,12 +188,12 @@ void GameWorld::inputAndUpdate() {
     std::vector<Item*>& StaticItems = map.getStaticItems();
 
 
-    // std::cerr << "Mario state: " << mario.getState() << std::endl;
+    // std::cerr << "Player state: " << player.getState() << std::endl;
     // std::cerr << "GameWorld state: " << state << std::endl;
     // std::cerr << "gravity: " << gravity << std::endl;
-    if ( mario.getState() != SPRITE_STATE_DYING && 
-         mario.getState() != SPRITE_STATE_VICTORY &&
-         mario.getState() != SPRITE_STATE_WAITING_TO_NEXT_MAP &&
+    if ( player.getState() != SPRITE_STATE_DYING && 
+         player.getState() != SPRITE_STATE_VICTORY &&
+         player.getState() != SPRITE_STATE_WAITING_TO_NEXT_MAP &&
          state != GAME_STATE_TITLE_SCREEN &&
          state != GAME_STATE_MENU_SCREEN &&
          state != GAME_STATE_MAP_EDITOR_SCREEN1 &&
@@ -216,21 +216,21 @@ void GameWorld::inputAndUpdate() {
          state != GAME_STATE_SETTINGS_SCREEN &&
          state != GAME_STATE_HELPING_SCREEN &&
          state != GAME_STATE_GUARD_SCREEN ) {
-        mario.setActivationWidth( GetScreenWidth() * 2 );
-        mario.update();
-    } else if ( !pauseMario && state != GAME_STATE_TITLE_SCREEN && 
+        player.setActivationWidth( GetScreenWidth() * 2 );
+        player.update();
+    } else if ( !pausePlayer && state != GAME_STATE_TITLE_SCREEN && 
         state != GAME_STATE_MENU_SCREEN &&
         state != GAME_STATE_MAP_EDITOR_SCREEN1 &&
         state != GAME_STATE_MAP_EDITOR_SCREEN2 &&
         state != GAME_STATE_SELECT_CHARACTER_SCREEN &&
         state != GAME_STATE_CREDITS_SCREEN) {
 
-        mario.update();
+        player.update();
     }
 
-    if ( mario.getState() != SPRITE_STATE_DYING && 
-         mario.getState() != SPRITE_STATE_VICTORY &&
-         mario.getState() != SPRITE_STATE_WAITING_TO_NEXT_MAP &&
+    if ( player.getState() != SPRITE_STATE_DYING && 
+         player.getState() != SPRITE_STATE_VICTORY &&
+         player.getState() != SPRITE_STATE_WAITING_TO_NEXT_MAP &&
          state != GAME_STATE_TITLE_SCREEN &&
          state != GAME_STATE_MENU_SCREEN &&
          state != GAME_STATE_MAP_EDITOR_SCREEN1 &&
@@ -277,7 +277,7 @@ void GameWorld::inputAndUpdate() {
 
         for ( const auto& baddie : Baddies ) {
             baddie->update();
-            baddie->followTheLeader( &mario );
+            baddie->followTheLeader( &player );
             // OPTIMIZATION: Update collision probes once per baddie
             baddie->updateCollisionProbes();
         }
@@ -288,45 +288,45 @@ void GameWorld::inputAndUpdate() {
         }
 
         // tiles collision resolution
-        mario.updateCollisionProbes();
+        player.updateCollisionProbes();
         for ( const auto& tile : Tiles ) {
 
-            // mario x tiles - Distance-based collision optimization
-            if (shouldCheckCollision(mario.getPos(), mario.getDim(), tile->getPos(), tile->getDim(), maxDistForCollisionCheck)) {
-                CollisionType col = mario.checkCollision( tile );
+            // player x tiles - Distance-based collision optimization
+            if (shouldCheckCollision(player.getPos(), player.getDim(), tile->getPos(), tile->getDim(), maxDistForCollisionCheck)) {
+                CollisionType col = player.checkCollision( tile );
 
                 if ( tile->getType() == TILE_TYPE_SOLID ) {
                     switch ( col ) {
                         case COLLISION_TYPE_NORTH:
-                            mario.setY( tile->getY() + tile->getHeight() );
-                            mario.setVelY( 0 );
-                            mario.updateCollisionProbes();
+                            player.setY( tile->getY() + tile->getHeight() );
+                            player.setVelY( 0 );
+                            player.updateCollisionProbes();
                             break;
                         case COLLISION_TYPE_SOUTH:
-                            mario.setY( tile->getY() - mario.getHeight() );
-                            mario.setVelY( 0 );
-                            mario.setState( SPRITE_STATE_ON_GROUND );
-                            mario.updateCollisionProbes();
+                            player.setY( tile->getY() - player.getHeight() );
+                            player.setVelY( 0 );
+                            player.setState( SPRITE_STATE_ON_GROUND );
+                            player.updateCollisionProbes();
                             break;
                         case COLLISION_TYPE_EAST:
-                            mario.setX( tile->getX() - mario.getWidth() );
-                            mario.setVelX( 0 );
-                            mario.updateCollisionProbes();
+                            player.setX( tile->getX() - player.getWidth() );
+                            player.setVelX( 0 );
+                            player.updateCollisionProbes();
                             break;
                         case COLLISION_TYPE_WEST:
-                            mario.setX( tile->getX() + tile->getWidth() );
-                            mario.setVelX( 0 );
-                            mario.updateCollisionProbes();
+                            player.setX( tile->getX() + tile->getWidth() );
+                            player.setVelX( 0 );
+                            player.updateCollisionProbes();
                             break;
                         default:
                             break;
                     }
                 } else if ( tile->getType() == TILE_TYPE_SOLID_FROM_ABOVE ) {
-                    if ( col == COLLISION_TYPE_SOUTH && mario.getState() == SPRITE_STATE_FALLING ) {
-                        mario.setY( tile->getY() - mario.getHeight() );
-                        mario.setVelY( 0 );
-                        mario.setState( SPRITE_STATE_ON_GROUND );
-                        mario.updateCollisionProbes();
+                    if ( col == COLLISION_TYPE_SOUTH && player.getState() == SPRITE_STATE_FALLING ) {
+                        player.setY( tile->getY() - player.getHeight() );
+                        player.setVelY( 0 );
+                        player.setState( SPRITE_STATE_ON_GROUND );
+                        player.updateCollisionProbes();
                     }
                 }
             }
@@ -388,7 +388,7 @@ void GameWorld::inputAndUpdate() {
                             case COLLISION_TYPE_SOUTH:
                                 item->setY( tile->getY() - item->getHeight() );
                                 item->setVelY( 0 );
-                                item->onSouthCollision( mario );
+                                item->onSouthCollision( player );
                                 item->updateCollisionProbes();
                                 break;
                             case COLLISION_TYPE_EAST:
@@ -413,34 +413,34 @@ void GameWorld::inputAndUpdate() {
         }
 
         // blocks collision resolution
-        mario.updateCollisionProbes();
+        player.updateCollisionProbes();
 
         for ( const auto& block : Blocks ) {
 
-            // mario x blocks - Distance-based collision optimization
-            if (shouldCheckCollision(mario.getPos(), mario.getDim(), block->getPos(), block->getDim(), maxDistForCollisionCheck)) {
-                switch ( mario.checkCollision( block ) ) {
+            // player x blocks - Distance-based collision optimization
+            if (shouldCheckCollision(player.getPos(), player.getDim(), block->getPos(), block->getDim(), maxDistForCollisionCheck)) {
+                switch ( player.checkCollision( block ) ) {
                     case COLLISION_TYPE_NORTH:
-                        mario.setY( block->getY() + block->getHeight() );
-                        mario.setVelY( 0 );
-                        mario.updateCollisionProbes();
-                        block->doHit( mario, &map );
+                        player.setY( block->getY() + block->getHeight() );
+                        player.setVelY( 0 );
+                        player.updateCollisionProbes();
+                        block->doHit( player, &map );
                         break;
                     case COLLISION_TYPE_SOUTH:
-                        mario.setY( block->getY() - mario.getHeight() );
-                        mario.setVelY( 0 );
-                        mario.setState( SPRITE_STATE_ON_GROUND );
-                        mario.updateCollisionProbes();
+                        player.setY( block->getY() - player.getHeight() );
+                        player.setVelY( 0 );
+                        player.setState( SPRITE_STATE_ON_GROUND );
+                        player.updateCollisionProbes();
                         break;
                     case COLLISION_TYPE_EAST:
-                        mario.setX( block->getX() - mario.getWidth() );
-                        mario.setVelX( 0 );
-                        mario.updateCollisionProbes();
+                        player.setX( block->getX() - player.getWidth() );
+                        player.setVelX( 0 );
+                        player.updateCollisionProbes();
                         break;
                     case COLLISION_TYPE_WEST:
-                        mario.setX( block->getX() + block->getWidth() );
-                        mario.setVelX( 0 );
-                        mario.updateCollisionProbes();
+                        player.setX( block->getX() + block->getWidth() );
+                        player.setVelX( 0 );
+                        player.updateCollisionProbes();
                         break;
                     default:
                         break;
@@ -499,7 +499,7 @@ void GameWorld::inputAndUpdate() {
                         case COLLISION_TYPE_SOUTH:
                             item->setY( block->getY() - item->getHeight() );
                             item->setVelY( 0 );
-                            item->onSouthCollision( mario );
+                            item->onSouthCollision( player );
                             item->updateCollisionProbes();
                             break;
                         case COLLISION_TYPE_EAST:
@@ -521,7 +521,7 @@ void GameWorld::inputAndUpdate() {
 
         }
 
-        // mario x items collision resolution and offscreen items removal with distance optimization
+        // player x items collision resolution and offscreen items removal with distance optimization
         for ( size_t i = 0; i < Items.size(); i++ ) {
 
             Item* item = Items[i];
@@ -529,16 +529,16 @@ void GameWorld::inputAndUpdate() {
             if ( item->getState() != SPRITE_STATE_HIT &&
                  item->getState() != SPRITE_STATE_TO_BE_REMOVED ) {
                 
-                // Distance-based collision optimization: Only check collision if Mario is close to the item
-                if (shouldCheckCollision(mario.getPos(), mario.getDim(), item->getPos(), item->getDim(), maxDistForCollisionCheck)) {
-                    if ( item->checkCollision( &mario ) != COLLISION_TYPE_NONE ) {
-                        if ( !mario.isTransitioning() ) {
+                // Distance-based collision optimization: Only check collision if Player is close to the item
+                if (shouldCheckCollision(player.getPos(), player.getDim(), item->getPos(), item->getDim(), maxDistForCollisionCheck)) {
+                    if ( item->checkCollision( &player ) != COLLISION_TYPE_NONE ) {
+                        if ( !player.isTransitioning() ) {
                             item->setState( SPRITE_STATE_HIT );
                             item->playCollisionSound();
                             if ( item->isPauseGameOnHit() ) {
                                 pauseGame( false, false, false, false, false );
                             }
-                            item->updateMario( mario );
+                            item->updatePlayer( player );
                         }
                     }
                 } else if ( item->getY() > map.getMaxHeight() ) {
@@ -557,7 +557,7 @@ void GameWorld::inputAndUpdate() {
             Items.erase( Items.begin() + collectedIndexes[i] );
         }
         
-        // mario x static items collision resolution with distance optimization
+        // player x static items collision resolution with distance optimization
         collectedIndexes.clear();
         for ( size_t i = 0; i < StaticItems.size(); i++ ) {
 
@@ -566,12 +566,12 @@ void GameWorld::inputAndUpdate() {
             if ( item->getState() != SPRITE_STATE_HIT &&
                  item->getState() != SPRITE_STATE_TO_BE_REMOVED ) {
                 
-                // Distance-based collision optimization: Only check collision if Mario is close to the static item
-                if (shouldCheckCollision(mario.getPos(), mario.getDim(), item->getPos(), item->getDim(), maxDistForCollisionCheck)) {
-                    if ( item->checkCollision( &mario ) != COLLISION_TYPE_NONE ) {
+                // Distance-based collision optimization: Only check collision if Player is close to the static item
+                if (shouldCheckCollision(player.getPos(), player.getDim(), item->getPos(), item->getDim(), maxDistForCollisionCheck)) {
+                    if ( item->checkCollision( &player ) != COLLISION_TYPE_NONE ) {
                         item->setState( SPRITE_STATE_HIT );
                         item->playCollisionSound();
-                        item->updateMario( mario );
+                        item->updatePlayer( player );
                     }
                 } else if ( item->getY() > map.getMaxHeight() ) {
                     item->setState( SPRITE_STATE_TO_BE_REMOVED );
@@ -589,13 +589,13 @@ void GameWorld::inputAndUpdate() {
             StaticItems.erase( StaticItems.begin() + collectedIndexes[i] );
         }
 
-        // baddies activation and mario and fireballs x baddies collision resolution and offscreen baddies removal
+        // baddies activation and player and fireballs x baddies collision resolution and offscreen baddies removal
         collectedIndexes.clear();
-        if ( mario.getState() != SPRITE_STATE_DYING && 
-             mario.getState() != SPRITE_STATE_VICTORY &&
-             mario.getState() != SPRITE_STATE_WAITING_TO_NEXT_MAP ) {
+        if ( player.getState() != SPRITE_STATE_DYING && 
+             player.getState() != SPRITE_STATE_VICTORY &&
+             player.getState() != SPRITE_STATE_WAITING_TO_NEXT_MAP ) {
 
-            mario.updateCollisionProbes();
+            player.updateCollisionProbes();
 
             for ( size_t i = 0; i < Baddies.size(); i++ ) {
 
@@ -603,85 +603,85 @@ void GameWorld::inputAndUpdate() {
 
                 // baddies activation
                 if ( baddie->getState() == SPRITE_STATE_IDLE ) {
-                    baddie->activateWithMarioProximity( mario );
+                    baddie->activateWithPlayerProximity( player );
                 }
 
                 if ( baddie->getState() != SPRITE_STATE_DYING && 
                      baddie->getState() != SPRITE_STATE_TO_BE_REMOVED ) {
 
-                    // Distance-based collision optimization: Only check collision if Mario is close to the baddie
-                    if (shouldCheckCollision(mario.getPos(), mario.getDim(), baddie->getPos(), baddie->getDim(), maxDistForCollisionCheck)) {
-                        const CollisionType col = mario.checkCollisionBaddie( baddie );
+                    // Distance-based collision optimization: Only check collision if Player is close to the baddie
+                    if (shouldCheckCollision(player.getPos(), player.getDim(), baddie->getPos(), baddie->getDim(), maxDistForCollisionCheck)) {
+                        const CollisionType col = player.checkCollisionBaddie( baddie );
 
-                        if ( mario.isInvincible() && col ) {
+                        if ( player.isInvincible() && col ) {
                             baddie->onHit();
                             PlaySound( sounds["stomp"] );
-                            mario.addPoints( baddie->getEarnedPoints() );
+                            player.addPoints( baddie->getEarnedPoints() );
                         } else {
 
                             if ( baddie->getAuxiliaryState() != SPRITE_STATE_INVULNERABLE ) {
 
-                                // mario and fireballs x baddies collision resolution and offscreen baddies removal
+                                // player and fireballs x baddies collision resolution and offscreen baddies removal
                                 switch ( col ) {
                                     case COLLISION_TYPE_NORTH:
                                     case COLLISION_TYPE_EAST:
                                     case COLLISION_TYPE_WEST:
-                                        if ( !mario.isImmortal() && !mario.isInvulnerable() ) {
-                                            switch ( mario.getType() ) {
-                                                case MARIO_TYPE_SMALL:
-                                                    mario.setState( SPRITE_STATE_DYING );
-                                                    mario.playPlayerDownMusicStream();
-                                                    mario.removeLives( 1 );
+                                        if ( !player.isImmortal() && !player.isInvulnerable() ) {
+                                            switch ( player.getType() ) {
+                                                case PLAYER_TYPE_SMALL:
+                                                    player.setState( SPRITE_STATE_DYING );
+                                                    player.playPlayerDownMusicStream();
+                                                    player.removeLives( 1 );
                                                     break;
-                                                case MARIO_TYPE_SUPER:
+                                                case PLAYER_TYPE_SUPER:
                                                     PlaySound( sounds["pipe"] );
-                                                    mario.setLastStateBeforeTransition( mario.getState() );
-                                                    mario.setState( SPRITE_STATE_TRANSITIONING_SUPER_TO_SMALL );
-                                                mario.setInvulnerable( true );
+                                                    player.setLastStateBeforeTransition( player.getState() );
+                                                    player.setState( SPRITE_STATE_TRANSITIONING_SUPER_TO_SMALL );
+                                                player.setInvulnerable( true );
                                                 break;
-                                            case MARIO_TYPE_FLOWER:
+                                            case PLAYER_TYPE_FLOWER:
                                                 PlaySound( sounds["pipe"] );
-                                                mario.setLastStateBeforeTransition( mario.getState() );
-                                                mario.setState( SPRITE_STATE_TRANSITIONING_FLOWER_TO_SMALL );
-                                                mario.setInvulnerable( true );
+                                                player.setLastStateBeforeTransition( player.getState() );
+                                                player.setState( SPRITE_STATE_TRANSITIONING_FLOWER_TO_SMALL );
+                                                player.setInvulnerable( true );
                                                 break;
                                         }
                                     }
                                     break;
                                 case COLLISION_TYPE_SOUTH:
-                                    if ( mario.getState() == SPRITE_STATE_FALLING && 
+                                    if ( player.getState() == SPRITE_STATE_FALLING && 
                                          baddie->getState() != SPRITE_STATE_DYING && 
                                          baddie->getState() != SPRITE_STATE_TO_BE_REMOVED ) {
-                                        mario.setY( baddie->getY() - mario.getHeight() );
+                                        player.setY( baddie->getY() - player.getHeight() );
                                         if ( ( IsKeyDown( KEY_LEFT_CONTROL ) ||
                                                IsGamepadButtonDown( 0, GAMEPAD_BUTTON_RIGHT_FACE_LEFT ) ) ) {
-                                            mario.setVelY( -400 );
+                                            player.setVelY( -400 );
                                         } else {
-                                            mario.setVelY( -200 );
+                                            player.setVelY( -200 );
                                         }
-                                        mario.setState( SPRITE_STATE_JUMPING );
+                                        player.setState( SPRITE_STATE_JUMPING );
                                         baddie->onHit();
                                         PlaySound( sounds["stomp"] );
-                                        mario.addPoints( baddie->getEarnedPoints() );
+                                        player.addPoints( baddie->getEarnedPoints() );
                                     } else {
-                                        if ( !mario.isImmortal() && !mario.isInvulnerable() ) {
-                                            switch ( mario.getType() ) {
-                                                case MARIO_TYPE_SMALL:
-                                                    mario.setState( SPRITE_STATE_DYING );
-                                                    mario.playPlayerDownMusicStream();
-                                                    mario.removeLives( 1 );
+                                        if ( !player.isImmortal() && !player.isInvulnerable() ) {
+                                            switch ( player.getType() ) {
+                                                case PLAYER_TYPE_SMALL:
+                                                    player.setState( SPRITE_STATE_DYING );
+                                                    player.playPlayerDownMusicStream();
+                                                    player.removeLives( 1 );
                                                     break;
-                                                case MARIO_TYPE_SUPER:
+                                                case PLAYER_TYPE_SUPER:
                                                     PlaySound( sounds["pipe"] );
-                                                    mario.setLastStateBeforeTransition( mario.getState() );
-                                                    mario.setState( SPRITE_STATE_TRANSITIONING_SUPER_TO_SMALL );
-                                                    mario.setInvulnerable( true );
+                                                    player.setLastStateBeforeTransition( player.getState() );
+                                                    player.setState( SPRITE_STATE_TRANSITIONING_SUPER_TO_SMALL );
+                                                    player.setInvulnerable( true );
                                                     break;
-                                                case MARIO_TYPE_FLOWER:
+                                                case PLAYER_TYPE_FLOWER:
                                                     PlaySound( sounds["pipe"] );
-                                                    mario.setLastStateBeforeTransition( mario.getState() );
-                                                    mario.setState( SPRITE_STATE_TRANSITIONING_FLOWER_TO_SMALL );
-                                                    mario.setInvulnerable( true );
+                                                    player.setLastStateBeforeTransition( player.getState() );
+                                                    player.setState( SPRITE_STATE_TRANSITIONING_FLOWER_TO_SMALL );
+                                                    player.setInvulnerable( true );
                                                     break;
                                             }
                                         }
@@ -690,7 +690,7 @@ void GameWorld::inputAndUpdate() {
                                 case COLLISION_TYPE_FIREBALL:
                                     baddie->onHit();
                                     PlaySound( sounds["stomp"] );
-                                    mario.addPoints( baddie->getEarnedPoints() );
+                                    player.addPoints( baddie->getEarnedPoints() );
                                     break;
                                 default:
                                     break;
@@ -703,26 +703,26 @@ void GameWorld::inputAndUpdate() {
                                 if ( col == COLLISION_TYPE_FIREBALL ) {
                                     baddie->onHit();
                                     PlaySound( sounds["stomp"] );
-                                    mario.addPoints( baddie->getEarnedPoints() );
+                                    player.addPoints( baddie->getEarnedPoints() );
                                 } else {
-                                    if ( !mario.isImmortal() && !mario.isInvulnerable() ) {
-                                        switch ( mario.getType() ) {
-                                            case MARIO_TYPE_SMALL:
-                                                mario.setState( SPRITE_STATE_DYING );
-                                                mario.playPlayerDownMusicStream();
-                                                mario.removeLives( 1 );
+                                    if ( !player.isImmortal() && !player.isInvulnerable() ) {
+                                        switch ( player.getType() ) {
+                                            case PLAYER_TYPE_SMALL:
+                                                player.setState( SPRITE_STATE_DYING );
+                                                player.playPlayerDownMusicStream();
+                                                player.removeLives( 1 );
                                                 break;
-                                            case MARIO_TYPE_SUPER:
+                                            case PLAYER_TYPE_SUPER:
                                                 PlaySound( sounds["pipe"] );
-                                                mario.setLastStateBeforeTransition( mario.getState() );
-                                                mario.setState( SPRITE_STATE_TRANSITIONING_SUPER_TO_SMALL );
-                                                mario.setInvulnerable( true );
+                                                player.setLastStateBeforeTransition( player.getState() );
+                                                player.setState( SPRITE_STATE_TRANSITIONING_SUPER_TO_SMALL );
+                                                player.setInvulnerable( true );
                                                 break;
-                                            case MARIO_TYPE_FLOWER:
+                                            case PLAYER_TYPE_FLOWER:
                                                 PlaySound( sounds["pipe"] );
-                                                mario.setLastStateBeforeTransition( mario.getState() );
-                                                mario.setState( SPRITE_STATE_TRANSITIONING_FLOWER_TO_SMALL );
-                                                mario.setInvulnerable( true );
+                                                player.setLastStateBeforeTransition( player.getState() );
+                                                player.setState( SPRITE_STATE_TRANSITIONING_FLOWER_TO_SMALL );
+                                                player.setInvulnerable( true );
                                                 break;
                                         }
                                     }
@@ -753,7 +753,7 @@ void GameWorld::inputAndUpdate() {
                     collectedIndexes.push_back( static_cast<int>( i ) );
                 }
 
-                mario.updateCollisionProbes();
+                player.updateCollisionProbes();
 
             }
 
@@ -775,26 +775,26 @@ void GameWorld::inputAndUpdate() {
         }
     }
 
-    else if (mario.getState() == SPRITE_STATE_DYING) {
-            if ( !mario.isPlayerDownMusicStreamPlaying() && !mario.isGameOverMusicStreamPlaying() ) {
+    else if (player.getState() == SPRITE_STATE_DYING) {
+            if ( !player.isPlayerDownMusicStreamPlaying() && !player.isGameOverMusicStreamPlaying() ) {
             
-            if ( mario.getLives() > 0 ) {
+            if ( player.getLives() > 0 ) {
                 resetMap();
-            } else if ( mario.getLives() < 0 ) {
+            } else if ( player.getLives() < 0 ) {
                 resetGame();
             } else {
-                mario.playGameOverMusicStream();
+                player.playGameOverMusicStream();
                 state = GAME_STATE_GAME_OVER;
-                mario.setLives( -1 );
+                player.setLives( -1 );
             }
         }
     }
 
-    else if ( mario.getState() == SPRITE_STATE_VICTORY ) {
-        remainingTimePointCount = mario.getRemainingTime();
+    else if ( player.getState() == SPRITE_STATE_VICTORY ) {
+        remainingTimePointCount = player.getRemainingTime();
         state = GAME_STATE_COUNTING_POINTS;
         map.setDrawBlackScreen( true );
-        mario.setState( SPRITE_STATE_WAITING_TO_NEXT_MAP );
+        player.setState( SPRITE_STATE_WAITING_TO_NEXT_MAP );
     }
 
     else if (state == GAME_STATE_COUNTING_POINTS) {
@@ -805,7 +805,7 @@ void GameWorld::inputAndUpdate() {
         }
 
         remainingTimePointCount--;
-        mario.addPoints( 50 );
+        player.addPoints( 50 );
 
         if ( remainingTimePointCount % 3 == 0 ) {
             PlaySound( sounds["coin"] );
@@ -865,7 +865,7 @@ void GameWorld::inputAndUpdate() {
             pauseButtonsCooldownAcum = pauseButtonsCooldownTime;
             // Ensure we maintain the correct pause state
             pauseMusic = true;
-            pauseMario = true;
+            pausePlayer = true;
         }
         else if (guardScreen->getAcceptButton()->isReleased()) {
             // Execute the guarded action
@@ -874,7 +874,7 @@ void GameWorld::inputAndUpdate() {
                 state = GAME_STATE_TITLE_SCREEN;
                 settingBoardIsOpen = false;
                 pauseMusic = false;
-                pauseMario = false;
+                pausePlayer = false;
             }
             else if (guardScreen->getCurrentAction() == GUARD_ACTION_RESET) {
                 resetMap();
@@ -901,30 +901,30 @@ void GameWorld::inputAndUpdate() {
         }
     }
 
-    if ( mario.getState() != SPRITE_STATE_DYING && 
-         mario.getY() > map.getMaxHeight() ) {
+    if ( player.getState() != SPRITE_STATE_DYING && 
+         player.getY() > map.getMaxHeight() ) {
 
-        mario.setState( SPRITE_STATE_DYING );
-        mario.playPlayerDownMusicStream();
-        mario.removeLives( 1 );
+        player.setState( SPRITE_STATE_DYING );
+        player.playPlayerDownMusicStream();
+        player.removeLives( 1 );
     }
 
     const float xc = GetScreenWidth() / 2.0;
     const float yc = GetScreenHeight() / 2.0;
-    const float pxc = mario.getX() + mario.getWidth() / 2.0;
-    const float pyc = mario.getY() + mario.getHeight() / 2.0;
+    const float pxc = player.getX() + player.getWidth() / 2.0;
+    const float pyc = player.getY() + player.getHeight() / 2.0;
     
     camera->offset.x = xc;
 
     if ( pxc < xc ) {
         camera->target.x = xc + Map::TILE_WIDTH;
-        map.setMarioOffset( 0 );         // x parallax
+        map.setPlayerOffset( 0 );         // x parallax
     } else if ( pxc >= map.getMaxWidth() - xc - Map::TILE_WIDTH ) {
         camera->target.x = map.getMaxWidth() - GetScreenWidth();
         camera->offset.x = 0;
     } else {
         camera->target.x = pxc + Map::TILE_WIDTH;
-        map.setMarioOffset( pxc - xc );  // x parallax
+        map.setPlayerOffset( pxc - xc );  // x parallax
     }
 
     camera->offset.y = yc;
@@ -1007,10 +1007,10 @@ void GameWorld::inputAndUpdate() {
         else if (state == GAME_STATE_SELECT_CHARACTER_SCREEN) {
             if (selectCharacterScreen->getMarioButton().isReleased()) {
                 // Mario selected - start the game
-                mario.resetAll();
-				mario.toMario(); // Switch to Mario
+                player.resetAll();
+				player.toMario(); // Switch to Mario
                 map.loadFromJsonFile(); // Load the map immediately
-                mario.setMaxTime(400.0f); // Set the time limit (400 seconds = typical Mario game time)
+                player.setMaxTime(400.0f); // Set the time limit (400 seconds = typical Mario game time)
                 
                 if (IsMusicStreamPlaying(musics["title"])) {
                     StopMusicStream(musics["title"]);
@@ -1022,10 +1022,10 @@ void GameWorld::inputAndUpdate() {
                 // Luigi selected - implement later
                 // std::cout << "Luigi button pressed. Luigi functionality will be implemented later." << std::endl;
 
-                mario.resetAll();
-				mario.toLuigi(); // Switch to Luigi
+                player.resetAll();
+				player.toLuigi(); // Switch to Luigi
                 map.loadFromJsonFile(); // Load the map immediately
-                mario.setMaxTime(400.0f); // Set the time limit (400 seconds = typical Mario game time)
+                player.setMaxTime(400.0f); // Set the time limit (400 seconds = typical Mario game time)
 
                 if (IsMusicStreamPlaying(musics["title"])) {
                     StopMusicStream(musics["title"]);
@@ -1067,7 +1067,7 @@ void GameWorld::inputAndUpdate() {
     }
 
     else if ( state == GAME_STATE_GAME_OVER ) {
-        mario.playGameOverMusicStream();
+        player.playGameOverMusicStream();
     }
       
 }
@@ -1124,7 +1124,7 @@ void GameWorld::draw() {
         BeginMode2D(*camera);
         map.draw();
         EndMode2D();
-        mario.drawHud();
+        player.drawHud();
         settingButton->draw();
         helpButton->draw();
 
@@ -1145,24 +1145,24 @@ void GameWorld::draw() {
             drawString( message1, sc.x - getDrawStringWidth( message1 ) / 2, sc.y - 80 );
 
             int clockWidth = textures["guiClock"].width;
-            int remainingTimeWidth = getSmallNumberWidth( mario.getRemainingTime() );
+            int remainingTimeWidth = getSmallNumberWidth( player.getRemainingTime() );
             int pointsPerSecondWidth = getSmallNumberWidth( 50 );
             int timesWidth = textures["guiX"].width;
             int equalSignWidth = getDrawStringWidth( "=" );
-            int totalTimePoints = mario.getRemainingTime() * 50;
+            int totalTimePoints = player.getRemainingTime() * 50;
             int totalTimePointsWidth = getSmallNumberWidth( totalTimePoints );
             int completeMessageWidth = clockWidth + remainingTimeWidth + pointsPerSecondWidth + timesWidth + equalSignWidth + totalTimePointsWidth;
             int completeMessageStart = sc.x - (completeMessageWidth/2);
             int completeMessageY = sc.y - 40;
 
             DrawTexture( textures["guiClock"], completeMessageStart, completeMessageY, WHITE );
-            drawWhiteSmallNumber( mario.getRemainingTime(), completeMessageStart + clockWidth, completeMessageY );
+            drawWhiteSmallNumber( player.getRemainingTime(), completeMessageStart + clockWidth, completeMessageY );
             DrawTexture( textures["guiX"], completeMessageStart + clockWidth + remainingTimeWidth, completeMessageY, WHITE );
             drawWhiteSmallNumber( 50, completeMessageStart + clockWidth + remainingTimeWidth + timesWidth, completeMessageY );
             drawString( "=", completeMessageStart + clockWidth + remainingTimeWidth + timesWidth + pointsPerSecondWidth, completeMessageY - 4 );
             drawWhiteSmallNumber( totalTimePoints, completeMessageStart + clockWidth + remainingTimeWidth + timesWidth + pointsPerSecondWidth + equalSignWidth, completeMessageY );
 
-            Vector2 centerFunnel = GetWorldToScreen2D( mario.getCenter(), *camera );
+            Vector2 centerFunnel = GetWorldToScreen2D( player.getCenter(), *camera );
             DrawRing( centerFunnel, 
                       sqrt( GetScreenWidth() * GetScreenWidth() + GetScreenHeight() * GetScreenHeight() ) * ( 1 -  outroAcum / outroTime ),
                       GetScreenWidth() * 2, 
@@ -1238,14 +1238,14 @@ void GameWorld::addToTotalPlayedTime(float timeToAdd) {
 }
 
 void GameWorld::resetMap() {
-    mario.reset(true);
+    player.reset(true);
     map.reset();
     map.loadFromJsonFile(); 
     state = GAME_STATE_PLAYING;
 }
 
 void GameWorld::resetGame() {
-    mario.resetAll();
+    player.resetAll();
     map.first();
     map.reset();
     totalPlayedTime = 0; // Reset total played time when starting a new game
@@ -1255,22 +1255,22 @@ void GameWorld::resetGame() {
 void GameWorld::nextMap() {
     if (map.hasNext()) {
         state = GAME_STATE_PLAYING;
-        // Add Mario's elapsed time to total played time when map is completed
-        totalPlayedTime += static_cast<int>(mario.getEllapsedTime());
-        mario.setPointsFromPreviousMap(mario.getPoints());
-        mario.setCoinsFromPreviousMap(mario.getCoins());
-        mario.reset(false, false);
+        // Add Player's elapsed time to total played time when map is completed
+        totalPlayedTime += static_cast<int>(player.getEllapsedTime());
+        player.setPointsFromPreviousMap(player.getPoints());
+        player.setCoinsFromPreviousMap(player.getCoins());
+        player.reset(false, false);
     } else {
         state = GAME_STATE_FINISHED;
     }
 }
 
-void GameWorld::pauseGame(bool playPauseSFX, bool pauseMusic, bool pauseMario, bool showSettingBoard, bool showHelpingBoard) {
+void GameWorld::pauseGame(bool playPauseSFX, bool pauseMusic, bool pausePlayer, bool showSettingBoard, bool showHelpingBoard) {
     if (playPauseSFX) {
         PlaySound(ResourceManager::getInstance().getSounds()["pause"]);
     }
     this->pauseMusic = pauseMusic;
-    this->pauseMario = pauseMario;
+    this->pausePlayer = pausePlayer;
     settingBoardIsOpen = showSettingBoard;
     helpingBoardIsOpen = showHelpingBoard;
     this->stateBeforePause = state;
@@ -1281,7 +1281,7 @@ void GameWorld::pauseGame(bool playPauseSFX, bool pauseMusic, bool pauseMario, b
 void GameWorld::unpauseGame() {
     state = stateBeforePause;
     pauseMusic = false;
-    pauseMario = false;
+    pausePlayer = false;
     
     // Start cooldown timer if settings screen was open
     if (settingBoardIsOpen || helpingBoardIsOpen) {
@@ -1301,7 +1301,7 @@ void GameWorld::showGuardScreen(GuardAction action) {
         state = GAME_STATE_GUARD_SCREEN;
         guardScreen->setAction(action);
         pauseMusic = true;
-        pauseMario = true;
+        pausePlayer = true;
         settingBoardIsOpen = false;
         helpingBoardIsOpen = false;
     }

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -1,6 +1,6 @@
 ﻿#include "Item.h"
 #include "ResourceManager.h"
-#include "Mario.h"
+#include "Player.h"
 #include "GameWorld.h"
 #include "raylib.h"
 #include "Sprite.h"
@@ -41,7 +41,7 @@ Item::Item(Vector2 pos, Vector2 dim, Vector2 vel, Color color, float frameTime, 
 }
 
 Item::~Item() = default;
-void Item::onSouthCollision(Mario& mario) {}
+void Item::onSouthCollision(Player& player) {}
 bool Item::isPauseGameOnHit() {
     return pauseGameOnHit;
 }
@@ -106,12 +106,12 @@ void Coin::playCollisionSound() {
   
 }
 
-void Coin::updateMario(Mario& mario) {
-    mario.addCoins(1);
-    mario.addPoints(earnedPoints);
-    if (mario.getCoins() >= 100) {
-        mario.addLives(1);
-        mario.setCoins(mario.getCoins() - 100);
+void Coin::updatePlayer(Player& player) {
+    player.addCoins(1);
+    player.addPoints(earnedPoints);
+    if (player.getCoins() >= 100) {
+        player.addLives(1);
+        player.setCoins(player.getCoins() - 100);
     }
 }
 
@@ -203,48 +203,48 @@ void Mushroom::playCollisionSound() {
     
 }
 
-void Mushroom::updateMario(Mario& mario) {
+void Mushroom::updatePlayer(Player& player) {
 
-    mario.addPoints(earnedPoints);
+    player.addPoints(earnedPoints);
 
-    switch (mario.getType()) {
-    case MARIO_TYPE_SMALL:
-        mario.setY(mario.getY() - 16);
-        mario.setLastStateBeforeTransition(mario.getState());
-        mario.setState(SPRITE_STATE_TRANSITIONING_SMALL_TO_SUPER);
+    switch (player.getType()) {
+    case PLAYER_TYPE_SMALL:
+        player.setY(player.getY() - 16);
+        player.setLastStateBeforeTransition(player.getState());
+        player.setState(SPRITE_STATE_TRANSITIONING_SMALL_TO_SUPER);
         break;
-    case MARIO_TYPE_SUPER:
-        switch (mario.getReservedPowerUp()) {
-        case MARIO_TYPE_SMALL:
-            mario.setReservedPowerUp(MARIO_TYPE_SUPER);
+    case PLAYER_TYPE_SUPER:
+        switch (player.getReservedPowerUp()) {
+        case PLAYER_TYPE_SMALL:
+            player.setReservedPowerUp(PLAYER_TYPE_SUPER);
             break;
-        case MARIO_TYPE_SUPER:
+        case PLAYER_TYPE_SUPER:
             break;
-        case MARIO_TYPE_FLOWER:
+        case PLAYER_TYPE_FLOWER:
             break;
         }
-        mario.getGameWorld()->unpauseGame();
+        player.getGameWorld()->unpauseGame();
         break;
-    case MARIO_TYPE_FLOWER:
-        switch (mario.getReservedPowerUp()) {
-        case MARIO_TYPE_SMALL:
-            mario.setReservedPowerUp(MARIO_TYPE_SUPER);
+    case PLAYER_TYPE_FLOWER:
+        switch (player.getReservedPowerUp()) {
+        case PLAYER_TYPE_SMALL:
+            player.setReservedPowerUp(PLAYER_TYPE_SUPER);
             break;
-        case MARIO_TYPE_SUPER:
+        case PLAYER_TYPE_SUPER:
             break;
-        case MARIO_TYPE_FLOWER:
+        case PLAYER_TYPE_FLOWER:
             break;
         }
-        mario.getGameWorld()->unpauseGame();
+        player.getGameWorld()->unpauseGame();
         break;
     }
 
 }
 
-void Mushroom::onSouthCollision(Mario& mario) {
+void Mushroom::onSouthCollision(Player& player) {
     if (doCollisionOnGround) {
         vel.x = 200;
-        facingDirection = mario.getFacingDirection();
+        facingDirection = player.getFacingDirection();
         blinking = false;
         doBlink = false;
         doCollisionOnGround = false;
@@ -312,8 +312,8 @@ void OneUpMushroom::playCollisionSound() {
     
 }
 
-void OneUpMushroom::updateMario(Mario& mario) {
-    mario.addLives(1); 
+void OneUpMushroom::updatePlayer(Player& player) {
+    player.addLives(1); 
     state = SPRITE_STATE_HIT; 
 	//play sound
 }
@@ -396,47 +396,47 @@ void FireFlower::playCollisionSound() {
     
 }
 
-void FireFlower::updateMario(Mario& mario) {
+void FireFlower::updatePlayer(Player& player) {
 
-    mario.addPoints(earnedPoints);
+    player.addPoints(earnedPoints);
 
-    switch (mario.getType()) {
-    case MARIO_TYPE_SMALL:
-        mario.setY(mario.getY() - 16);
-        mario.setLastStateBeforeTransition(mario.getState());
-        mario.setState(SPRITE_STATE_TRANSITIONING_SMALL_TO_FLOWER);
+    switch (player.getType()) {
+    case PLAYER_TYPE_SMALL:
+        player.setY(player.getY() - 16);
+        player.setLastStateBeforeTransition(player.getState());
+        player.setState(SPRITE_STATE_TRANSITIONING_SMALL_TO_FLOWER);
         break;
-    case MARIO_TYPE_SUPER:
-        mario.setLastStateBeforeTransition(mario.getState());
-        mario.setState(SPRITE_STATE_TRANSITIONING_SUPER_TO_FLOWER);
-        switch (mario.getReservedPowerUp()) {
-        case MARIO_TYPE_SMALL:
-            mario.setReservedPowerUp(MARIO_TYPE_SUPER);
+    case PLAYER_TYPE_SUPER:
+        player.setLastStateBeforeTransition(player.getState());
+        player.setState(SPRITE_STATE_TRANSITIONING_SUPER_TO_FLOWER);
+        switch (player.getReservedPowerUp()) {
+        case PLAYER_TYPE_SMALL:
+            player.setReservedPowerUp(PLAYER_TYPE_SUPER);
             break;
-        case MARIO_TYPE_SUPER:
+        case PLAYER_TYPE_SUPER:
             break;
-        case MARIO_TYPE_FLOWER:
+        case PLAYER_TYPE_FLOWER:
             break;
         }
         break;
-    case MARIO_TYPE_FLOWER:
-        switch (mario.getReservedPowerUp()) {
-        case MARIO_TYPE_SMALL:
-            mario.setReservedPowerUp(MARIO_TYPE_FLOWER);        
+    case PLAYER_TYPE_FLOWER:
+        switch (player.getReservedPowerUp()) {
+        case PLAYER_TYPE_SMALL:
+            player.setReservedPowerUp(PLAYER_TYPE_FLOWER);        
             break;
-        case MARIO_TYPE_SUPER:
-            mario.setReservedPowerUp(MARIO_TYPE_FLOWER);           
+        case PLAYER_TYPE_SUPER:
+            player.setReservedPowerUp(PLAYER_TYPE_FLOWER);           
             break;
-        case MARIO_TYPE_FLOWER:
+        case PLAYER_TYPE_FLOWER:
             break;
         }
-        mario.getGameWorld()->unpauseGame();
+        player.getGameWorld()->unpauseGame();
         break;
     }
 
 }
 
-void FireFlower::onSouthCollision(Mario& mario) {
+void FireFlower::onSouthCollision(Player& player) {
     if (doCollisionOnGround) {
         blinking = false;
         doBlink = false;
@@ -503,13 +503,13 @@ void Star::playCollisionSound() {
 
 }
 
-void Star::updateMario(Mario& mario) {
-    mario.setInvincible(true); 
+void Star::updatePlayer(Player& player) {
+    player.setInvincible(true); 
     state = SPRITE_STATE_HIT; 
 	//play sound
 }
 
-void Star::onSouthCollision(Mario& mario) {
+void Star::onSouthCollision(Player& player) {
     vel.y = -400;
 }
 
@@ -567,8 +567,8 @@ void ThreeUpMoon::playCollisionSound() {
 
 }
 
-void ThreeUpMoon::updateMario(Mario& mario) {
-    mario.addLives(3); 
+void ThreeUpMoon::updatePlayer(Player& player) {
+    player.addLives(3); 
     state = SPRITE_STATE_HIT; 
 	//play sound
 }
@@ -652,12 +652,12 @@ void YoshiCoin::playCollisionSound() {
 
 }
 
-void YoshiCoin::updateMario(Mario& mario) {
-    mario.addYoshiCoins(1);
-    mario.addPoints(earnedPoints);
-    if (mario.getYoshiCoins() == 5) {
-        mario.addLives(1);
-        mario.setYoshiCoins(0);
+void YoshiCoin::updatePlayer(Player& player) {
+    player.addYoshiCoins(1);
+    player.addPoints(earnedPoints);
+    if (player.getYoshiCoins() == 5) {
+        player.addLives(1);
+        player.setYoshiCoins(0);
     }
 }
 
@@ -726,9 +726,9 @@ void CourseClearToken::playCollisionSound() {
  
 }
 
-void CourseClearToken::updateMario(Mario& mario) {
-    mario.addPoints(earnedPoints);
-    mario.setState(SPRITE_STATE_VICTORY);
+void CourseClearToken::updatePlayer(Player& player) {
+    player.addPoints(earnedPoints);
+    player.setState(SPRITE_STATE_VICTORY);
 }
 
 CollisionType CourseClearToken::checkCollision(Sprite* sprite) {

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -52,7 +52,7 @@ const std::vector<Color> Map::backgroundColorPallete = {
     { 2, 38, 83, 255 },     // Dark blue
 };
 
-Map::Map(Mario& mario, int id, bool loadTestMap, GameWorld* gw) :
+Map::Map(Player& player, int id, bool loadTestMap, GameWorld* gw) :
 
     id(id),
     maxId(3),
@@ -60,8 +60,8 @@ Map::Map(Mario& mario, int id, bool loadTestMap, GameWorld* gw) :
     maxWidth(0),
     maxHeight(0),
 
-    mario(mario),
-    marioOffset(0),
+    player(player),
+    playerOffset(0),
     backgroundId(1),
     maxBackgroundId(3),
     backgroundColor(WHITE),
@@ -71,7 +71,7 @@ Map::Map(Mario& mario, int id, bool loadTestMap, GameWorld* gw) :
     drawBlackScreenFadeTime(1.5),
 
     // Near sight vision effect for map3
-    lastValidMarioPos({0, 0}),
+    lastValidPlayerPos({0, 0}),
 
     //tileSetId(1),
     //maxTileSetId(4),
@@ -127,7 +127,7 @@ void Map::loadFromJsonFile(bool shouldLoadTestMap) {
     }
 
     loadTestMap = shouldLoadTestMap;
-    mario.setPos(100, 1688);
+    player.setPos(100, 1688);
 
     std::string jsonFilePath;
     if (loadTestMap) {
@@ -467,7 +467,7 @@ void Map::draw() {
         for (int i = 0; i <= repeats; i++) {
             DrawTexture(
                 backgroundTexture,
-                -backgroundTexture.width + i * backgroundTexture.width - marioOffset * 0.06,
+                -backgroundTexture.width + i * backgroundTexture.width - playerOffset * 0.06,
                 maxHeight - backgroundTexture.height,
                 WHITE);
         }
@@ -506,19 +506,19 @@ void Map::draw() {
     
     }
     
-    mario.draw();
+    player.draw();
 
     Vector2 pos{10.0f, GetScreenHeight() - 20.0f};
     Vector2 drawPos = GetScreenToWorld2D(pos, *camera);
     
     if (id == 3) {  // Near sight vision effect for map3
-        // Update last valid Mario position when he's not dying
-        if (mario.getState() != SPRITE_STATE_DYING) {
-            lastValidMarioPos = mario.getPos();
+        // Update last valid Player position when he's not dying
+        if (player.getState() != SPRITE_STATE_DYING) {
+            lastValidPlayerPos = player.getPos();
         }
         
         for (float radius = 0; radius < GetScreenWidth() * 1.5f; radius += GetScreenWidth() / 100.0f) {
-            DrawRing(lastValidMarioPos, radius, GetScreenWidth() * 1.5f, 0.0f, 360.0f, 32, Fade(BLACK, 0.07f));
+            DrawRing(lastValidPlayerPos, radius, GetScreenWidth() * 1.5f, 0.0f, 360.0f, 32, Fade(BLACK, 0.07f));
         }
     }
 
@@ -559,7 +559,7 @@ void Map::playMusic() const {
        std::map<std::string, Music> musics = ResourceManager::getInstance().getMusics();
        const std::string key(TextFormat("music%d", musicId));
 
-       if (mario.isInvincible()) {
+       if (player.isInvincible()) {
            if (IsMusicStreamPlaying(musics[key])) {
                StopMusicStream(musics[key]);
            }
@@ -593,8 +593,8 @@ float Map::getMaxHeight() const {
     return maxHeight;
 }
 
-void Map::setMarioOffset(float marioOffset) {
-   this->marioOffset = marioOffset;
+void Map::setPlayerOffset(float playerOffset) {
+   this->playerOffset = playerOffset;
 }
 
 void Map::setDrawBlackScreen(bool drawBlackScreen) {
@@ -617,12 +617,12 @@ void Map::reset() {
 
     maxWidth = 0;
     maxHeight = 0;
-    marioOffset = 0;
+    playerOffset = 0;
     drawBlackScreen = false;
     drawBlackScreenFadeAcum = 0;
 
     // Reset near sight vision position
-    lastValidMarioPos = {0, 0};
+    lastValidPlayerPos = {0, 0};
 
     for (const auto& tile : untouchableTiles) {
         delete tile;

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -2,7 +2,7 @@
 #include "GameState.h"
 #include "GameWorld.h"
 #include "Map.h"
-#include "Mario.h"
+#include "Player.h"
 #include "raylib.h"
 #include "ResourceManager.h"
 #include <iostream>
@@ -11,7 +11,7 @@
 // #include "FireFlower.h"
 // #include "Mushroom.h"
 
-Mario::Mario( Vector2 pos, Vector2 dim, Vector2 vel, Color color, float speedX, float maxSpeedX, float jumpSpeed, bool immortal ) :
+Player::Player( Vector2 pos, Vector2 dim, Vector2 vel, Color color, float speedX, float maxSpeedX, float jumpSpeed, bool immortal ) :
 	Sprite( pos, dim, vel, color, 0, 2),
 	speedX( speedX ),
 	maxSpeedX( maxSpeedX ),
@@ -34,8 +34,8 @@ Mario::Mario( Vector2 pos, Vector2 dim, Vector2 vel, Color color, float speedX, 
     pointsFromPreviousMap(0),
     maxTime(400.0f),  // Set default time limit to 400 seconds (typical Mario game time)
     ellapsedTime(0.0f),
-    type(MARIO_TYPE_SMALL),
-    reservedPowerUp(MARIO_TYPE_SMALL),
+    type(PLAYER_TYPE_SMALL),
+    reservedPowerUp(PLAYER_TYPE_SMALL),
     runningAcum(0),
     runningTime(0.5),
     drawRunningFrames(false),
@@ -70,9 +70,9 @@ Mario::Mario( Vector2 pos, Vector2 dim, Vector2 vel, Color color, float speedX, 
 
 }
 
-Mario::~Mario() = default;
+Player::~Player() = default;
 
-void Mario::update() {
+void Player::update() {
     const float delta = GetFrameTime();
     float accelRate = isLuigi ? 0.6f : 1.0f; // Luigi accelerates slower than Mario
 
@@ -270,7 +270,7 @@ void Mario::update() {
                 }
             }
 
-            if (IsKeyPressed(KEY_LEFT_CONTROL) && type == MARIO_TYPE_FLOWER) {
+            if (IsKeyPressed(KEY_LEFT_CONTROL) && type == PLAYER_TYPE_FLOWER) {
 
                 if (facingDirection == DIRECTION_RIGHT) {
                     fireballs.push_back(Fireball(Vector2{ pos.x + dim.x / 2, pos.y + dim.y / 2 - 3 }, Vector2{ 16, 16 }, Vector2{ 400, 100 }, RED, DIRECTION_RIGHT, 2));
@@ -309,20 +309,20 @@ void Mario::update() {
 
 }
 
-void Mario::draw() {
+void Player::draw() {
 
     std::map<std::string, Texture2D>& textures = ResourceManager::getInstance().getTextures();
     std::string prefix;
 
     switch (type) {
     default:
-    case MARIO_TYPE_SMALL:
+    case PLAYER_TYPE_SMALL:
         prefix = "small";
         break;
-    case MARIO_TYPE_SUPER:
+    case PLAYER_TYPE_SUPER:
         prefix = "super";
         break;
-    case MARIO_TYPE_FLOWER:
+    case PLAYER_TYPE_FLOWER:
         prefix = "flower";
         break;
     }
@@ -371,7 +371,7 @@ void Mario::draw() {
                         DrawTexture(textures[std::string(TextFormat("%sMario%dRu%c", prefix.c_str(), currentFrame, dir))], pos.x, pos.y, tint);
                     }
                     else { // idle
-                        if (IsKeyPressed(KEY_LEFT_CONTROL) && type == MARIO_TYPE_FLOWER) {
+                        if (IsKeyPressed(KEY_LEFT_CONTROL) && type == PLAYER_TYPE_FLOWER) {
                             DrawTexture(textures[std::string(TextFormat("%sMario%dTf%c", prefix.c_str(), currentFrame, dir))], pos.x, pos.y, tint);
                         }
                         else {
@@ -444,7 +444,7 @@ void Mario::draw() {
                         DrawTexture(textures[std::string(TextFormat("%sLuigi%dRu%c", prefix.c_str(), currentFrame, dir))], pos.x, pos.y, tint);
                     }
                     else { // idle
-                        if (IsKeyPressed(KEY_LEFT_CONTROL) && type == MARIO_TYPE_FLOWER) {
+                        if (IsKeyPressed(KEY_LEFT_CONTROL) && type == PLAYER_TYPE_FLOWER) {
                             DrawTexture(textures[std::string(TextFormat("%sLuigi%dTf%c", prefix.c_str(), currentFrame, dir))], pos.x, pos.y, tint);
                         }
                         else {
@@ -485,7 +485,7 @@ void Mario::draw() {
 
 }
 
-CollisionType Mario::checkCollision(Sprite* sprite) {
+CollisionType Player::checkCollision(Sprite* sprite) {
 
     if (sprite->getState() != SPRITE_STATE_NO_COLLIDABLE) {
 
@@ -539,7 +539,7 @@ CollisionType Mario::checkCollision(Sprite* sprite) {
 
 }
 
-CollisionType Mario::checkCollisionBaddie(Sprite* sprite) {
+CollisionType Player::checkCollisionBaddie(Sprite* sprite) {
     
     if (sprite->getState() != SPRITE_STATE_NO_COLLIDABLE) {
         Rectangle rect = sprite->getRect();
@@ -571,7 +571,7 @@ CollisionType Mario::checkCollisionBaddie(Sprite* sprite) {
 	return COLLISION_TYPE_NONE;
 }
 
-void Mario::drawHud() const {
+void Player::drawHud() const {
 	std::map<std::string, Texture2D>& textures = ResourceManager::getInstance().getTextures(); // Getting textures from ResourceManager
 
 	// Left side of the screen
@@ -597,15 +597,15 @@ void Mario::drawHud() const {
 	drawYellowSmallNumber(t, GetScreenWidth() - 34 - 128 - getSmallNumberWidth(t) - leftshift, 50); // Draw remaining time
 
 	// Center top of the screen
-    if (reservedPowerUp == MARIO_TYPE_SUPER) {
+    if (reservedPowerUp == PLAYER_TYPE_SUPER) {
         DrawTexture(textures["mushroom"], GetScreenWidth() / 2 - textures["mushroom"].width / 2, 32, WHITE);
-    } else if (reservedPowerUp == MARIO_TYPE_FLOWER) {
+    } else if (reservedPowerUp == PLAYER_TYPE_FLOWER) {
         DrawTexture(textures["fireFlower0"], GetScreenWidth() / 2 - textures["fireFlower0"].width / 2, 32, WHITE);
     }
 	DrawTexture(textures["guiNextItem"], GetScreenWidth() / 2 - textures["guiNextItem"].width / 2, 20, WHITE);
 }
 
-void Mario::updateCollisionProbes() {
+void Player::updateCollisionProbes() {
 
     cpN.setX(pos.x + dim.x / 2 - cpN.getWidth() / 2);
     if (ducking) {
@@ -623,7 +623,7 @@ void Mario::updateCollisionProbes() {
     cpW.setX(pos.x);
     cpW1.setX(pos.x);
 
-    if (type == MARIO_TYPE_SMALL) {
+    if (type == PLAYER_TYPE_SMALL) {
 
         if (ducking) {
             cpE.setY(pos.y + 21 - cpE.getHeight() / 2);
@@ -658,190 +658,190 @@ void Mario::updateCollisionProbes() {
 
 }
 
-float Mario::getSpeedX() const {
+float Player::getSpeedX() const {
     return speedX;
 }
 
-float Mario::getMaxSpeedX() const {
+float Player::getMaxSpeedX() const {
     return maxSpeedX;
 }
 
-float Mario::getJumpSpeed() const {
+float Player::getJumpSpeed() const {
     return jumpSpeed;
 }
 
-float Mario::getActivationWidth() const {
+float Player::getActivationWidth() const {
     return activationWidth;
 }
 
-void Mario::setImmortal(bool immortal) {
+void Player::setImmortal(bool immortal) {
     this->immortal = immortal;
 }
 
-bool Mario::isImmortal() const {
+bool Player::isImmortal() const {
     return immortal;
 }
 
-void Mario::setActivationWidth(float activationWidth) {
+void Player::setActivationWidth(float activationWidth) {
     this->activationWidth = activationWidth;
 }
 
-void Mario::setLives(int lives) {
+void Player::setLives(int lives) {
     this->lives = lives;
 }
 
-void Mario::setCoins(int coins) {
+void Player::setCoins(int coins) {
     this->coins = coins;
 }
 
-void Mario::setCoinsFromPreviousMap(int coinsFromPreviousMap) {
+void Player::setCoinsFromPreviousMap(int coinsFromPreviousMap) {
     this->coinsFromPreviousMap = coinsFromPreviousMap;
 }
 
-void Mario::setYoshiCoins(int yoshiCoins) {
+void Player::setYoshiCoins(int yoshiCoins) {
     this->yoshiCoins = yoshiCoins;
 }
 
-void Mario::setPoints(int points) {
+void Player::setPoints(int points) {
     this->points = points;
 }
 
-void Mario::setPointsFromPreviousMap(int pointsFromPreviousMap) {
+void Player::setPointsFromPreviousMap(int pointsFromPreviousMap) {
     this->pointsFromPreviousMap = pointsFromPreviousMap;
 }
 
-int Mario::getRemainingTime() const {
+int Player::getRemainingTime() const {
     return static_cast<int>(maxTime - ellapsedTime);
 }
 
-float Mario::getEllapsedTime() const {
+float Player::getEllapsedTime() const {
     return ellapsedTime;
 }
 
-void Mario::setMaxTime(float maxTime) {
+void Player::setMaxTime(float maxTime) {
     this->maxTime = maxTime;
 }
 
-void Mario::setLastStateBeforeTransition(SpriteState lastStateBeforeTransition) {
+void Player::setLastStateBeforeTransition(SpriteState lastStateBeforeTransition) {
     this->lastStateBeforeTransition = lastStateBeforeTransition;
 }
 
-void Mario::setGameWorld(GameWorld* gw) {
+void Player::setGameWorld(GameWorld* gw) {
     this->gw = gw;
 }
 
-void Mario::setMap(Map* map) {
+void Player::setMap(Map* map) {
     this->map = map;
 }
 
-GameWorld* Mario::getGameWorld() const {
+GameWorld* Player::getGameWorld() const {
     return gw;
 }
 
-Map* Mario::getMap() const {
+Map* Player::getMap() const {
     return map;
 }
 
-int Mario::getLives() const {
+int Player::getLives() const {
     return lives;
 }
 
-int Mario::getCoins() const {
+int Player::getCoins() const {
     return coins;
 }
 
-int Mario::getCoinsFromPreviousMap() const {
+int Player::getCoinsFromPreviousMap() const {
     return coinsFromPreviousMap;
 }
 
-int Mario::getYoshiCoins() const {
+int Player::getYoshiCoins() const {
     return yoshiCoins;
 }
 
-int Mario::getPoints() const {
+int Player::getPoints() const {
     return points;
 }
 
-int Mario::getPointsFromPreviousMap() const {
+int Player::getPointsFromPreviousMap() const {
     return pointsFromPreviousMap;
 }
 
-void Mario::addLives(int lives) {
+void Player::addLives(int lives) {
     this->lives += lives;
 }
 
-void Mario::removeLives(int lives) {
+void Player::removeLives(int lives) {
     this->lives -= lives;
 }
 
-void Mario::addCoins(int coins) {
+void Player::addCoins(int coins) {
     this->coins += coins;
 }
 
-void Mario::addYoshiCoins(int yoshiCoins) {
+void Player::addYoshiCoins(int yoshiCoins) {
     this->yoshiCoins += yoshiCoins;
 }
 
-void Mario::removeCoins(int coins) {
+void Player::removeCoins(int coins) {
     this->coins -= coins;
 }
 
-void Mario::addPoints(int points) {
+void Player::addPoints(int points) {
     this->points += points;
 }
 
-void Mario::removePoints(int points) {
+void Player::removePoints(int points) {
     this->points -= points;
 }
 
-void Mario::changeToSmall() {
-    type = MARIO_TYPE_SMALL;
+void Player::changeToSmall() {
+    type = PLAYER_TYPE_SMALL;
     pos.y = pos.y + 12;
     dim.y = 40;
     maxFrames = 2;
 }
 
-void Mario::changeToSuper() {
-    type = MARIO_TYPE_SUPER;
+void Player::changeToSuper() {
+    type = PLAYER_TYPE_SUPER;
     dim.y = 56;
     maxFrames = 3;
 }
 
-void Mario::changeToFlower() {
-    type = MARIO_TYPE_FLOWER;
+void Player::changeToFlower() {
+    type = PLAYER_TYPE_FLOWER;
     dim.y = 56;
     maxFrames = 3;
 }
 
-void Mario::setReservedPowerUp(MarioType reservedPowerUp) {
+void Player::setReservedPowerUp(PlayerType reservedPowerUp) {
     this->reservedPowerUp = reservedPowerUp;
 }
 
-MarioType Mario::getReservedPowerUp() const {
+PlayerType Player::getReservedPowerUp() const {
     return reservedPowerUp;
 }
 
-MarioType Mario::getType() const {
+PlayerType Player::getType() const {
     return type;
 }
 
-void Mario::setInvulnerable(bool invulnerable) {
+void Player::setInvulnerable(bool invulnerable) {
     this->invulnerable = invulnerable;
 }
 
-bool Mario::isInvulnerable() const {
+bool Player::isInvulnerable() const {
     return invulnerable;
 }
 
-void Mario::setInvincible(bool invincible) {
+void Player::setInvincible(bool invincible) {
     this->invincible = invincible;
 }
 
-bool Mario::isInvincible() const {
+bool Player::isInvincible() const {
     return invincible;
 }
 
-bool Mario::isTransitioning() const {
+bool Player::isTransitioning() const {
     return state == SPRITE_STATE_TRANSITIONING_SMALL_TO_SUPER ||
         state == SPRITE_STATE_TRANSITIONING_SMALL_TO_FLOWER ||
         state == SPRITE_STATE_TRANSITIONING_SUPER_TO_FLOWER ||
@@ -849,15 +849,15 @@ bool Mario::isTransitioning() const {
         state == SPRITE_STATE_TRANSITIONING_FLOWER_TO_SMALL;
 }
 
-void Mario::reset(bool removePowerUps) {
+void Player::reset(bool removePowerUps) {
     reset(removePowerUps, true);
 }
 
-void Mario::reset(bool removePowerUps, bool resetPointsToSaved) {
+void Player::reset(bool removePowerUps, bool resetPointsToSaved) {
 
     if (removePowerUps) {
         changeToSmall();
-        reservedPowerUp = MARIO_TYPE_SMALL;
+        reservedPowerUp = PLAYER_TYPE_SMALL;
     }
     vel.x = 0;
     vel.y = 0;
@@ -882,7 +882,7 @@ void Mario::reset(bool removePowerUps, bool resetPointsToSaved) {
 
 }
 
-void Mario::resetAll() {
+void Player::resetAll() {
     lives = 5;
     coins = 0;
     coinsFromPreviousMap = 0;
@@ -892,7 +892,7 @@ void Mario::resetAll() {
     reset(true);
 }
 
-void Mario::playPlayerDownMusicStream() {
+void Player::playPlayerDownMusicStream() {
 
     std::map<std::string, Music> musics = ResourceManager::getInstance().getMusics();
 
@@ -913,7 +913,7 @@ void Mario::playPlayerDownMusicStream() {
     }
 }
 
-void Mario::playGameOverMusicStream() {
+void Player::playGameOverMusicStream() {
 
     std::map<std::string, Music> musics = ResourceManager::getInstance().getMusics();
 
@@ -935,24 +935,24 @@ void Mario::playGameOverMusicStream() {
 
 }
 
-bool Mario::isPlayerDownMusicStreamPlaying() const {
+bool Player::isPlayerDownMusicStreamPlaying() const {
     return playerDownMusicStreamPlaying;
 }
 
-bool Mario::isGameOverMusicStreamPlaying() const {
+bool Player::isGameOverMusicStreamPlaying() const {
     return gameOverMusicStreamPlaying;
 }
 
-Vector2 Mario::getSouthCollisionProbePos() const {
+Vector2 Player::getSouthCollisionProbePos() const {
     return Vector2{ cpS.getX(), cpS.getY() };
 }
 
-void Mario::toLuigi() {
+void Player::toLuigi() {
     isLuigi = true;
     jumpSpeed = -700; // Luigi jumps higher than Mario
 }
 
-void Mario::toMario() {
+void Player::toMario() {
     isLuigi = false;
     jumpSpeed = -600; // Mario jumps lower than Luigi
 }


### PR DESCRIPTION
Introduces the ability to switch between Mario and Luigi, including a new isLuigi flag, character-specific acceleration and jump speed, and selection logic in GameWorld. Luigi now accelerates slower and jumps higher than Mario, with appropriate methods to toggle between characters. The class "Mario" will soon be updated to "Character".